### PR TITLE
Fix timeouts + new Jira Account id requirements

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,7 +60,6 @@ passport.use(new AtlassianOAuthStrategy({
   consumerKey:"neptune-the-dodle",
   consumerSecret:privateKey
 }, function(req, token, tokenSecret, profile, done) {
-    console.log('HELLO YES')
     process.nextTick(function() {
       console.log(token)
       console.log(tokenSecret)

--- a/app.js
+++ b/app.js
@@ -306,9 +306,12 @@ app.post('/comment-created', function(req, res) {
   if (webhookReason === "comment_created" && webhookData.comment.author.displayName != "GitHub Integration") {
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
-      // for each mentioned user thats signed up for this app, send slack msg
-      webhookData.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
-      
+
+
+      webhookData.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions);
+
+
+// for each mentioned user thats signed up for this app, send slack msg      
       userMentions.forEach(userMention => {
         // find if there is a user with that jira username in this app's DB
 

--- a/app.js
+++ b/app.js
@@ -327,6 +327,7 @@ app.post('/comment-created', function(req, res) {
 
                 console.log("almost returning, mention length: " + userMentions.length + " INDEX+1: " + index + 1)
                 if (userMentions.length === index + 1) {
+                  console.log("returned 1")
                   res.sendStatus(200)
                 }
               })
@@ -338,11 +339,11 @@ app.post('/comment-created', function(req, res) {
             // send a slack message to the user
             slack.sendCommentToUser(thisUser, webhookData).then(result => {
               // if this is the last user to msg, send 200 status
-              
-
-              console.log("almost returning IN ELSE, mention length: " + userMentions.length + " INDEX+1: " + index + 1)
+            
+              console.log("almost returning IN ELSE, mention length: " + userMentions.length + " INDEX: " + index)
 
               if (userMentions.length === index + 1) {
+                console.log("returned 2")
                 res.sendStatus(200)
               }
             })

--- a/app.js
+++ b/app.js
@@ -308,7 +308,7 @@ app.post('/comment-created', function(req, res) {
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
 
       try {
-        req.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
+        webhookData.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
       } 
       catch(error) {
         console.error(error);
@@ -316,8 +316,6 @@ app.post('/comment-created', function(req, res) {
 // for each mentioned user thats signed up for this app, send slack msg      
       userMentions.forEach(userMention => {
         // find if there is a user with that jira username in this app's DB
-
-        console.log("Getting username for: "+userMention)
         user.getByJiraUsername(userMention).then((thisUser, index) => {
 
           // check if this webhook contains a jira issue in payload

--- a/app.js
+++ b/app.js
@@ -306,13 +306,8 @@ app.post('/comment-created', function(req, res) {
   if (webhookReason === "comment_created" && webhookData.comment.author.displayName != "GitHub Integration") {
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
-
       try {
-        req.body.comment.body = "a"
-        webhookData.comment.body = "b"
-        commentBody = "c"
-
-        //utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
+        webhookData.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
       } 
       catch(error) {
         console.error(error);

--- a/app.js
+++ b/app.js
@@ -307,7 +307,7 @@ app.post('/comment-created', function(req, res) {
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
       try {
-        let temp = utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user);
+        let temp = await utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user)
         console.log("temp: " + temp)
         webhookData.comment.body = temp
       } 

--- a/app.js
+++ b/app.js
@@ -307,7 +307,9 @@ app.post('/comment-created', function(req, res) {
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
       try {
-        webhookData.comment.body = utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user);
+        let temp = utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user);
+        console.log("temp: " + temp)
+        webhookData.comment.body = temp
       } 
       catch(error) {
         console.error(error);

--- a/app.js
+++ b/app.js
@@ -308,7 +308,7 @@ app.post('/comment-created', function(req, res) {
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
 
       try {
-        req.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions);
+        req.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
       } 
       catch(error) {
         console.error(error);

--- a/app.js
+++ b/app.js
@@ -308,8 +308,7 @@ app.post('/comment-created', function(req, res) {
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
 
       try {
-
-      webhookData.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions);
+        req.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions);
       } 
       catch(error) {
         console.error(error);

--- a/app.js
+++ b/app.js
@@ -295,8 +295,7 @@ app.post('/msg-wake-up', function(req, res) {
 
 app.post('/comment-created', function(req, res) {
 
-  console.log ('Cement Created! ! ! ! ! ! ! ! ! ! ! ! ! ! ! !');
-
+  console.log("Comment Created.")
 
   let webhookReason = req.body.webhookEvent,
       webhookData = req.body,
@@ -305,8 +304,6 @@ app.post('/comment-created', function(req, res) {
   // continue if the webhook was sent to us because an issue was commented on
   // by someone other than our GitHub Integration
   if (webhookReason === "comment_created" && webhookData.comment.author.displayName != "GitHub Integration") {
-    console.log ('this aint github');
-
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
       // for each mentioned user thats signed up for this app, send slack msg
@@ -320,13 +317,10 @@ app.post('/comment-created', function(req, res) {
           // https://github.com/msolomonTMG/jira-comment-slack-notification/issues/17
           // TODO: we can clean this up with async/await
           if (!webhookData.issue) {
-            console.log("Not issue")
             const issueUrl = webhookData.comment.self.split('/comment')[0]
             jira.getTicketInfo(thisUser, issueUrl).then(issueData => {
               webhookData.issue = issueData
               // send a slack message to the user
-
-              console.log("Sending comment")
               slack.sendCommentToUser(thisUser, webhookData).then(result => {
                 // if this is the last user to msg, send 200 status
                 if (userMentions.length === index + 1) {
@@ -336,9 +330,7 @@ app.post('/comment-created', function(req, res) {
               .catch(err => { return res.sendStatus(500) })
             })
           } else {
-            console.log("issue")
             // send a slack message to the user
-            console.log("Sending comment")
             slack.sendCommentToUser(thisUser, webhookData).then(result => {
               // if this is the last user to msg, send 200 status
               if (userMentions.length === index + 1) {

--- a/app.js
+++ b/app.js
@@ -307,7 +307,7 @@ app.post('/comment-created', function(req, res) {
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
       // for each mentioned user thats signed up for this app, send slack msg
-      webhookData.req.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
+      webhookData.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
       
       userMentions.forEach(userMention => {
         // find if there is a user with that jira username in this app's DB

--- a/app.js
+++ b/app.js
@@ -312,15 +312,21 @@ app.post('/comment-created', function(req, res) {
       // for each mentioned user thats signed up for this app, send slack msg
       userMentions.forEach(userMention => {
         // find if there is a user with that jira username in this app's DB
+
+        console.log("Getting username for: "+userMention)
+        
         user.getByJiraUsername(userMention).then((thisUser, index) => {
           // check if this webhook contains a jira issue in payload
           // https://github.com/msolomonTMG/jira-comment-slack-notification/issues/17
           // TODO: we can clean this up with async/await
           if (!webhookData.issue) {
+            console.log("Not issue")
             const issueUrl = webhookData.comment.self.split('/comment')[0]
             jira.getTicketInfo(thisUser, issueUrl).then(issueData => {
               webhookData.issue = issueData
               // send a slack message to the user
+
+              console.log("Sending comment")
               slack.sendCommentToUser(thisUser, webhookData).then(result => {
                 // if this is the last user to msg, send 200 status
                 if (userMentions.length === index + 1) {
@@ -330,7 +336,9 @@ app.post('/comment-created', function(req, res) {
               .catch(err => { return res.sendStatus(500) })
             })
           } else {
+            console.log("issue")
             // send a slack message to the user
+            console.log("Sending comment")
             slack.sendCommentToUser(thisUser, webhookData).then(result => {
               // if this is the last user to msg, send 200 status
               if (userMentions.length === index + 1) {

--- a/app.js
+++ b/app.js
@@ -303,7 +303,6 @@ app.post('/comment-created', function(req, res) {
   // continue if the webhook was sent to us because an issue was commented on
   // by someone other than our GitHub Integration
   if (webhookReason === "comment_created" && webhookData.comment.author.displayName != "GitHub Integration") {
-    console.log("INCOMING /COMMENT_CREATED: "+ req);
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
         utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user).then(newBody => {
@@ -327,50 +326,38 @@ app.post('/comment-created', function(req, res) {
               slack.sendCommentToUser(thisUser, webhookData).then(result => {
                 // if this is the last user to msg, send 200 status
 
-                console.log("almost returning, mention length: " + userMentions.length + " INDEX+1: " + index + 1)
                 if (userMentions.length === index + 1) {
-                  console.log("returned 1")
                   res.sendStatus(200)
                 } else {
                   index = index + 1
                 }
               })
               .catch(err => {
-                console.log("Error 500 extra logs 1");
                  return res.sendStatus(500) })
             })
           } else {
             // send a slack message to the user
             slack.sendCommentToUser(thisUser, webhookData).then(result => {
               // if this is the last user to msg, send 200 status
-            
-              console.log("almost returning IN ELSE, mention length: " + userMentions.length + " INDEX: " + index)
-
+          
               if (userMentions.length === index + 1) {
-                console.log("returned 2")
                 res.sendStatus(200)
               } else {
                 index = index + 1
               }
             })
             .catch(err => {
-              console.log("Error 500 extra logs 2");
-
-               return res.sendStatus(500) })
+              return res.sendStatus(500) })
           }
 
         })
         .catch(noUser => { 
-          console.log("Error 500 extra logs 3");
-
           return res.sendStatus(200) })
 
       })
 
     })})
     .catch(noMentions => { 
-      console.log("Error 500 extra logs 4");
-
       return res.sendStatus(200) })
   }
 

--- a/app.js
+++ b/app.js
@@ -309,10 +309,12 @@ app.post('/comment-created', function(req, res) {
         utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user).then(newBody => {
         webhookData.comment.body = newBody
     
+        //MANUAL LOCK BECAUSE INDEX IS UNDEFINED:
+        let index = 0
 // for each mentioned user thats signed up for this app, send slack msg      
       userMentions.forEach(userMention => {
         // find if there is a user with that jira username in this app's DB
-        user.getByJiraUsername(userMention).then((thisUser, index) => {
+        user.getByJiraUsername(userMention).then((thisUser) => {
 
           // check if this webhook contains a jira issue in payload
           // https://github.com/msolomonTMG/jira-comment-slack-notification/issues/17
@@ -329,6 +331,8 @@ app.post('/comment-created', function(req, res) {
                 if (userMentions.length === index + 1) {
                   console.log("returned 1")
                   res.sendStatus(200)
+                } else {
+                  index = index + 1
                 }
               })
               .catch(err => {
@@ -345,6 +349,8 @@ app.post('/comment-created', function(req, res) {
               if (userMentions.length === index + 1) {
                 console.log("returned 2")
                 res.sendStatus(200)
+              } else {
+                index = index + 1
               }
             })
             .catch(err => {

--- a/app.js
+++ b/app.js
@@ -303,6 +303,7 @@ app.post('/comment-created', function(req, res) {
   // continue if the webhook was sent to us because an issue was commented on
   // by someone other than our GitHub Integration
   if (webhookReason === "comment_created" && webhookData.comment.author.displayName != "GitHub Integration") {
+    console.log("INCOMING /COMMENT_CREATED: "+ req);
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
         utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user).then(newBody => {
@@ -323,30 +324,47 @@ app.post('/comment-created', function(req, res) {
               // send a slack message to the user
               slack.sendCommentToUser(thisUser, webhookData).then(result => {
                 // if this is the last user to msg, send 200 status
+
+                console.log("almost returning, mention length: " + userMentions.length + " INDEX+1: " + index + 1)
                 if (userMentions.length === index + 1) {
                   res.sendStatus(200)
                 }
               })
-              .catch(err => { return res.sendStatus(500) })
+              .catch(err => {
+                console.log("Error 500 extra logs 1");
+                 return res.sendStatus(500) })
             })
           } else {
             // send a slack message to the user
             slack.sendCommentToUser(thisUser, webhookData).then(result => {
               // if this is the last user to msg, send 200 status
+              
+
+              console.log("almost returning IN ELSE, mention length: " + userMentions.length + " INDEX+1: " + index + 1)
+
               if (userMentions.length === index + 1) {
                 res.sendStatus(200)
               }
             })
-            .catch(err => { return res.sendStatus(500) })
+            .catch(err => {
+              console.log("Error 500 extra logs 2");
+
+               return res.sendStatus(500) })
           }
 
         })
-        .catch(noUser => { return res.sendStatus(200) })
+        .catch(noUser => { 
+          console.log("Error 500 extra logs 3");
+
+          return res.sendStatus(200) })
 
       })
 
     })})
-    .catch(noMentions => { return res.sendStatus(200) })
+    .catch(noMentions => { 
+      console.log("Error 500 extra logs 4");
+
+      return res.sendStatus(200) })
   }
 
 })

--- a/app.js
+++ b/app.js
@@ -308,7 +308,11 @@ app.post('/comment-created', function(req, res) {
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
 
       try {
-        req.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
+        req.body.comment.body = "a"
+        webhookData.comment.body = "b"
+        commentBody = "c"
+
+        //utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
       } 
       catch(error) {
         console.error(error);

--- a/app.js
+++ b/app.js
@@ -306,14 +306,9 @@ app.post('/comment-created', function(req, res) {
   if (webhookReason === "comment_created" && webhookData.comment.author.displayName != "GitHub Integration") {
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
-      try {
-        let temp = await utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user)
-        console.log("temp: " + temp)
-        webhookData.comment.body = temp
-      } 
-      catch(error) {
-        console.error(error);
-      }
+        utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user).then(newBody => {
+        webhookData.comment.body = newBody
+    
 // for each mentioned user thats signed up for this app, send slack msg      
       userMentions.forEach(userMention => {
         // find if there is a user with that jira username in this app's DB
@@ -351,7 +346,7 @@ app.post('/comment-created', function(req, res) {
 
       })
 
-    })
+    })})
     .catch(noMentions => { return res.sendStatus(200) })
   }
 

--- a/app.js
+++ b/app.js
@@ -307,10 +307,13 @@ app.post('/comment-created', function(req, res) {
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
 
+      try {
 
       webhookData.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions);
-
-
+      } 
+      catch(error) {
+        console.error(error);
+      }
 // for each mentioned user thats signed up for this app, send slack msg      
       userMentions.forEach(userMention => {
         // find if there is a user with that jira username in this app's DB

--- a/app.js
+++ b/app.js
@@ -311,7 +311,7 @@ app.post('/comment-created', function(req, res) {
         // find if there is a user with that jira username in this app's DB
 
         console.log("Getting username for: "+userMention)
-        
+        commentBody = "test";
         user.getByJiraUsername(userMention).then((thisUser, index) => {
           // check if this webhook contains a jira issue in payload
           // https://github.com/msolomonTMG/jira-comment-slack-notification/issues/17

--- a/app.js
+++ b/app.js
@@ -311,7 +311,7 @@ app.post('/comment-created', function(req, res) {
         // find if there is a user with that jira username in this app's DB
 
         console.log("Getting username for: "+userMention)
-        commentBody = "test";
+        webhookData.req.body = "test 2";
         user.getByJiraUsername(userMention).then((thisUser, index) => {
           // check if this webhook contains a jira issue in payload
           // https://github.com/msolomonTMG/jira-comment-slack-notification/issues/17

--- a/app.js
+++ b/app.js
@@ -307,12 +307,14 @@ app.post('/comment-created', function(req, res) {
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
       // for each mentioned user thats signed up for this app, send slack msg
+      webhookData.req.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
+      
       userMentions.forEach(userMention => {
         // find if there is a user with that jira username in this app's DB
 
         console.log("Getting username for: "+userMention)
-        webhookData.req.body = "test 2";
         user.getByJiraUsername(userMention).then((thisUser, index) => {
+
           // check if this webhook contains a jira issue in payload
           // https://github.com/msolomonTMG/jira-comment-slack-notification/issues/17
           // TODO: we can clean this up with async/await

--- a/app.js
+++ b/app.js
@@ -308,7 +308,7 @@ app.post('/comment-created', function(req, res) {
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
 
       try {
-        webhookData.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
+        req.body.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
       } 
       catch(error) {
         console.error(error);

--- a/app.js
+++ b/app.js
@@ -307,7 +307,7 @@ app.post('/comment-created', function(req, res) {
     // look for a user mention in the comment
     utils.getUserMentionsFromComment(commentBody).then(userMentions => {
       try {
-        webhookData.comment.body = utils.swapJiraAccountIdWithJiraName(commentBody, userMentions, user);
+        webhookData.comment.body = utils.swapJiraAccountIdWithJiraName(webhookData.comment.body, userMentions, user);
       } 
       catch(error) {
         console.error(error);

--- a/slack/index.js
+++ b/slack/index.js
@@ -89,11 +89,14 @@ bot.on('message', function(message) {
       case 'signup':
         helpers.getUsernameFromId(message.user).then(username => {
           user.getBySlackUsername(username).then(user => {
+
+            console.log(user)
             if (user) {
               bot.postMessageToUser(username, `You're already signed up!`).then(function() {
                 functions.sendSettingsToUser(user)
               })
             } else {
+              console.log('no user')
               bot.postMessageToUser(username, `Signup by <${APP_URL}user/create?slackUsername=${username}|clicking here>`)
             }
 
@@ -101,6 +104,7 @@ bot.on('message', function(message) {
         })
       break;
       default:
+        console.log('default is happening')
         helpers.getUsernameFromId(message.user).then(username => {
           let response = ':wave: I can only do a few things right now. Say `settings` to adjust your settings or say `signup` to signup!. I plan on getting smarter eventually!'
           bot.postMessageToUser(username, response).fail(function(data) {

--- a/slack/index.js
+++ b/slack/index.js
@@ -89,14 +89,11 @@ bot.on('message', function(message) {
       case 'signup':
         helpers.getUsernameFromId(message.user).then(username => {
           user.getBySlackUsername(username).then(user => {
-
-            console.log(user)
             if (user) {
               bot.postMessageToUser(username, `You're already signed up!`).then(function() {
                 functions.sendSettingsToUser(user)
               })
             } else {
-              console.log('no user')
               bot.postMessageToUser(username, `Signup by <${APP_URL}user/create?slackUsername=${username}|clicking here>`)
             }
 
@@ -104,7 +101,6 @@ bot.on('message', function(message) {
         })
       break;
       default:
-        console.log('default is happening')
         helpers.getUsernameFromId(message.user).then(username => {
           let response = ':wave: I can only do a few things right now. Say `settings` to adjust your settings or say `signup` to signup!. I plan on getting smarter eventually!'
           bot.postMessageToUser(username, response).fail(function(data) {

--- a/user/index.js
+++ b/user/index.js
@@ -7,8 +7,7 @@ var userSchema = new mongoose.Schema({
   jiraUsername: String,
   jiraToken: String,
   jiraTokenSecret: String,
-  jiraID: String
-
+  jiraShortName: String
 });
 
 var User = mongoose.model('Users', userSchema);
@@ -58,20 +57,6 @@ var functions = {
     })
   },
   getByJiraUsername: function(jiraUsername) {
-    return new Promise(function(resolve, reject) {
-      User.findOne({
-        jiraUsername: jiraUsername
-      }, function(err, user) {
-        if(!err) {
-          return resolve(user)
-        } else {
-          return reject(err)
-        }
-      })
-
-    });
-  },
-  getByJiraId: function(jiraId) {
     return new Promise(function(resolve, reject) {
       User.findOne({
         jiraUsername: jiraUsername

--- a/user/index.js
+++ b/user/index.js
@@ -39,7 +39,6 @@ var functions = {
   },
   create: function(userObj) {
     return new Promise(function (resolve, reject) {
-
       newUser = new User ({
         slackUsername: userObj.slackUsername
         // jiraUsername: utils.addJiraMarkupToUsername(userObj.jiraUsername),
@@ -61,15 +60,30 @@ var functions = {
       User.findOne({
         jiraUsername: jiraUsername
       }, function(err, user) {
+        console.log("USER HERE --------")
+        console.log(user);
+        if(user == null){
+          User.findOne({
+            jiraShortName: jiraUsername
+          }, function(err, user) {
+            console.log("USER HERE --------")
+            console.log(user);
+            if(!err) {
+              return resolve(user)
+            } else {
+              return reject(err)
+            }
+          })
+        }
         if(!err) {
           return resolve(user)
         } else {
           return reject(err)
         }
       })
-
     });
   },
+
   getBySlackUsername: function(slackUsername) {
     return new Promise(function(resolve, reject) {
       console.log("GETTING USER")

--- a/user/index.js
+++ b/user/index.js
@@ -74,12 +74,13 @@ var functions = {
               return reject(err)
             }
           })
-        }
+        } else {
         if(!err) {
           return resolve(user)
         } else {
           return reject(err)
         }
+      }
       })
     });
   },

--- a/user/index.js
+++ b/user/index.js
@@ -6,7 +6,9 @@ var userSchema = new mongoose.Schema({
   slackUsername: String,
   jiraUsername: String,
   jiraToken: String,
-  jiraTokenSecret: String
+  jiraTokenSecret: String,
+  jiraID: String
+
 });
 
 var User = mongoose.model('Users', userSchema);
@@ -57,7 +59,20 @@ var functions = {
   },
   getByJiraUsername: function(jiraUsername) {
     return new Promise(function(resolve, reject) {
+      User.findOne({
+        jiraUsername: jiraUsername
+      }, function(err, user) {
+        if(!err) {
+          return resolve(user)
+        } else {
+          return reject(err)
+        }
+      })
 
+    });
+  },
+  getByJiraId: function(jiraId) {
+    return new Promise(function(resolve, reject) {
       User.findOne({
         jiraUsername: jiraUsername
       }, function(err, user) {

--- a/user/index.js
+++ b/user/index.js
@@ -60,14 +60,10 @@ var functions = {
       User.findOne({
         jiraUsername: jiraUsername
       }, function(err, user) {
-        console.log("USER HERE --------")
-        console.log(user);
         if(user == null){
           User.findOne({
             jiraShortName: jiraUsername
           }, function(err, user) {
-            console.log("USER HERE --------")
-            console.log(user);
             if(!err) {
               return resolve(user)
             } else {

--- a/utils/index.js
+++ b/utils/index.js
@@ -20,6 +20,7 @@ var functions = {
     return username.split('[~')[1].split(']')[0]
   },
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
+    return new Promise(function(resolve, reject) {
     userMentions.forEach(userMention => {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
         commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
@@ -27,8 +28,8 @@ var functions = {
       })
     })
     return resolve(commentBody); 
-  }
-}
+  })
+}}
 
 
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -20,11 +20,8 @@ var functions = {
     return username.split('[~')[1].split(']')[0]
   },
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
-    console.log("swapping")
     userMentions.forEach(userMention => {
-      console.log("mentuon 1")
       user.getByJiraUsername(userMention).then((thisUser, index) => {
-        console.log("hello" + userMention.jiraShortName);
         commentBody.replace(userMention, thisUser.jiraShortName)
       })
     })

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,8 +1,10 @@
 var functions = {
   getUserMentionsFromComment: function(commentBody) {
-    console.log ('Getting');
+    console.log ('getUserMentionsFromComment');
 
     return new Promise(function(resolve, reject) {
+      console.log('getUserMentionsFromComment in promise')
+      
       let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.]+\])/g)
       if (userMentions.length > 0) {
         console.log ('GOT '+userMentions.length+' names');

--- a/utils/index.js
+++ b/utils/index.js
@@ -26,7 +26,7 @@ var functions = {
         console.log(commentBody) 
       })
     })
-    return resolve; 
+    return commentBody; 
   }
 }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -21,13 +21,13 @@ var functions = {
   },
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
     return new Promise(function(resolve, reject) {
-    let lock = userMention.length;
+    let lock = userMentions.length;
     let count = 0
     userMentions.forEach(userMention => {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
         commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
         count++
-        if (count == userMention.length) {
+        if (count == lock) {
           resolve(commentBody);
         }
       })

--- a/utils/index.js
+++ b/utils/index.js
@@ -19,10 +19,10 @@ var functions = {
   },
   swapJiraAccountIdWithJiraName: function(commentBody) {
     let regex = '/(\[~[a-zA-Z0-9\.:]+\])/g'
-
+    return 0
   },
   getUsernameFromId: function(userName) {
-    return 
+    return 0
   }
 }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -21,13 +21,17 @@ var functions = {
   },
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
     return new Promise(function(resolve, reject) {
+    let lock = userMention.length;
+    let count = 0
     userMentions.forEach(userMention => {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
         commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
-        console.log(commentBody) 
+        count++
+        if (count == userMention.length) {
+          resolve(commentBody);
+        }
       })
     })
-    return resolve(commentBody); 
   })
 }}
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -22,6 +22,7 @@ var functions = {
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
     userMentions.forEach(userMention => {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
+        console.log("jira short name: " thisUser.jiraShortName)
         commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
       })
     })

--- a/utils/index.js
+++ b/utils/index.js
@@ -2,13 +2,12 @@ var functions = {
   getUserMentionsFromComment: function(commentBody) {
 
     return new Promise(function(resolve, reject) {
-      console.log(commentBody)
+      console.log("Getting names from comment body")
       let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.:]+\])/g)
+      console.log ('Got '+userMentions.length);
       if (userMentions.length > 0) {
-        console.log ('GOT '+ userMentions.length + ' names');
         return resolve(userMentions)
       } else {
-        console.log('No matches found')
         return reject(false)
       }
     });

--- a/utils/index.js
+++ b/utils/index.js
@@ -22,9 +22,7 @@ var functions = {
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
     userMentions.forEach(userMention => {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
-        console.log("jira short name: " + thisUser.jiraShortName)
         commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
-        console.log("New comment body: "+commentBody);
       })
     })
     return commentBody; 

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,3 +1,6 @@
+const
+  user = require('./user'),
+
 var functions = {
   getUserMentionsFromComment: function(commentBody) {
     return new Promise(function(resolve, reject) {
@@ -17,7 +20,7 @@ var functions = {
   stripJiraMarkupFromUsername: function(username) {
     return username.split('[~')[1].split(']')[0]
   },
-  swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
+  swapJiraAccountIdWithJiraName: function(commentBody, userMentions) {
     console.log("swapping")
     userMentions.forEach(userMention => {
       console.log("mentuon 1")

--- a/utils/index.js
+++ b/utils/index.js
@@ -26,7 +26,7 @@ var functions = {
         console.log(commentBody) 
       })
     })
-    return commentBody; 
+    return resolve(commentBody); 
   }
 }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,4 @@
-const
-  user = require('../user')
+
 
 var functions = {
   getUserMentionsFromComment: function(commentBody) {
@@ -20,7 +19,7 @@ var functions = {
   stripJiraMarkupFromUsername: function(username) {
     return username.split('[~')[1].split(']')[0]
   },
-  swapJiraAccountIdWithJiraName: function(commentBody, userMentions) {
+  swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
     console.log("swapping")
     userMentions.forEach(userMention => {
       console.log("mentuon 1")

--- a/utils/index.js
+++ b/utils/index.js
@@ -23,6 +23,7 @@ var functions = {
     userMentions.forEach(userMention => {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
         commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
+        console.log(commentBody) 
       })
     })
     return commentBody; 

--- a/utils/index.js
+++ b/utils/index.js
@@ -22,7 +22,7 @@ var functions = {
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
     userMentions.forEach(userMention => {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
-        console.log("jira short name: " thisUser.jiraShortName)
+        console.log("jira short name: " + thisUser.jiraShortName)
         commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
       })
     })

--- a/utils/index.js
+++ b/utils/index.js
@@ -5,11 +5,17 @@ var functions = {
     return new Promise(function(resolve, reject) {
       console.log('getUserMentionsFromComment in promise')
       
+      try{ 
       let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.]+\])/g)
+      } catch {
+        console.log('getUserMentionsFromComment fail')
+      }
+      console.log(userMentions)
       if (userMentions.length > 0) {
-        console.log ('GOT '+userMentions.length+' names');
+        console.log ('GOT '+ userMentions.length + ' names');
         return resolve(userMentions)
       } else {
+        console.log('No matches found')
         return reject(false)
       }
     });

--- a/utils/index.js
+++ b/utils/index.js
@@ -24,6 +24,7 @@ var functions = {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
         console.log("jira short name: " + thisUser.jiraShortName)
         commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
+        console.log("New comment body: "+commentBody);
       })
     })
     return commentBody; 

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,5 @@
 const
-  user = require('./user'),
+  user = require('./user')
 
 var functions = {
   getUserMentionsFromComment: function(commentBody) {

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,6 +1,5 @@
 var functions = {
   getUserMentionsFromComment: function(commentBody) {
-
     return new Promise(function(resolve, reject) {
       console.log("Getting names from comment body")
       let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.:]+\])/g)
@@ -17,7 +16,16 @@ var functions = {
   },
   stripJiraMarkupFromUsername: function(username) {
     return username.split('[~')[1].split(']')[0]
+  },
+  swapJiraAccountIdWithJiraName: function(commentBody) {
+    let regex = '/(\[~[a-zA-Z0-9\.:]+\])/g'
+
+  },
+  getUsernameFromId: function(userName) {
+    return 
   }
 }
+
+
 
 module.exports = functions;

--- a/utils/index.js
+++ b/utils/index.js
@@ -26,7 +26,7 @@ var functions = {
         console.log(commentBody) 
       })
     })
-    return commentBody; 
+    return resolve; 
   }
 }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,5 +1,5 @@
 const
-  user = require('./user')
+  user = require('../user')
 
 var functions = {
   getUserMentionsFromComment: function(commentBody) {

--- a/utils/index.js
+++ b/utils/index.js
@@ -22,8 +22,6 @@ var functions = {
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
     userMentions.forEach(userMention => {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
-        console.log ("mention: "+userMention)
-        console.log ("shortName: "+jiraShortName);
         commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
       })
     })

--- a/utils/index.js
+++ b/utils/index.js
@@ -17,12 +17,13 @@ var functions = {
   stripJiraMarkupFromUsername: function(username) {
     return username.split('[~')[1].split(']')[0]
   },
-  swapJiraAccountIdWithJiraName: function(commentBody) {
-    let regex = '/(\[~[a-zA-Z0-9\.:]+\])/g'
-    return 0
-  },
-  getUsernameFromId: function(userName) {
-    return 0
+  swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
+    userMentions.forEach(userMention => {
+      user.getByJiraUsername(userMention).then((thisUser, index) => {
+        commentBody.replace(userMention, thisUser.jiraShortName)
+      })
+    })
+    return commentBody; 
   }
 }
 

--- a/utils/index.js
+++ b/utils/index.js
@@ -4,7 +4,7 @@ var functions = {
   getUserMentionsFromComment: function(commentBody) {
     return new Promise(function(resolve, reject) {
       console.log("Getting names from comment body")
-      let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.:]+\])/g)
+      let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.:\.-]+\])/g)
       console.log ('Got '+userMentions.length);
       if (userMentions.length > 0) {
         return resolve(userMentions)

--- a/utils/index.js
+++ b/utils/index.js
@@ -5,6 +5,7 @@ var functions = {
     return new Promise(function(resolve, reject) {
       let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.]+\])/g)
       if (userMentions.length > 0) {
+        console.log ('GOT '+userMentions.length+' names');
         return resolve(userMentions)
       } else {
         return reject(false)

--- a/utils/index.js
+++ b/utils/index.js
@@ -22,7 +22,9 @@ var functions = {
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
     userMentions.forEach(userMention => {
       user.getByJiraUsername(userMention).then((thisUser, index) => {
-        commentBody.replace(userMention, thisUser.jiraShortName)
+        console.log ("mention: "+userMention)
+        console.log ("shortName: "+jiraShortName);
+        commentBody = commentBody.replace(userMention, thisUser.jiraShortName)
       })
     })
     return commentBody; 

--- a/utils/index.js
+++ b/utils/index.js
@@ -4,12 +4,8 @@ var functions = {
 
     return new Promise(function(resolve, reject) {
       console.log('getUserMentionsFromComment in promise')
-      
-      try{ 
+      console.log(commentBody)
       let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.]+\])/g)
-      } catch {
-        console.log('getUserMentionsFromComment fail')
-      }
       console.log(userMentions)
       if (userMentions.length > 0) {
         console.log ('GOT '+ userMentions.length + ' names');

--- a/utils/index.js
+++ b/utils/index.js
@@ -18,8 +18,11 @@ var functions = {
     return username.split('[~')[1].split(']')[0]
   },
   swapJiraAccountIdWithJiraName: function(commentBody, userMentions, user) {
+    console.log("swapping")
     userMentions.forEach(userMention => {
+      console.log("mentuon 1")
       user.getByJiraUsername(userMention).then((thisUser, index) => {
+        console.log("hello" + userMention.jiraShortName);
         commentBody.replace(userMention, thisUser.jiraShortName)
       })
     })

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,12 +1,9 @@
 var functions = {
   getUserMentionsFromComment: function(commentBody) {
-    console.log ('getUserMentionsFromComment');
 
     return new Promise(function(resolve, reject) {
-      console.log('getUserMentionsFromComment in promise')
       console.log(commentBody)
-      let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.]+\])/g)
-      console.log(userMentions)
+      let userMentions = commentBody.match(/(\[~[a-zA-Z0-9\.:]+\])/g)
       if (userMentions.length > 0) {
         console.log ('GOT '+ userMentions.length + ' names');
         return resolve(userMentions)


### PR DESCRIPTION
Bunch of silly stuff in here:

1. **Jira account name problems**

Jira seems to have decided that it will send account IDs instead of jira names from their user API

This means most of the name checking logic is incompatible back and forth between slack/jira, and the account name regex did not work 

So: 

The regex has been updated to support `:` and `-`

It also then makes sure to swap the `"[~accountid:#####]"` user name format with the jira short name format so that way the comments from the bot contain the actual understandable names.

2. **Timeouts and duplicates**

For some reason the foreach index was undefined so we never actually returned the call for heroku, causing it to continually try. 

I didn't try to figure out why that happens I just made my own index instead. 

**CAVEAT & CURRENT MISSING FEATURE**

I had to manually manually go into mongo and change the format of the usernames. Here's an example: 

BEFORE:

```
{
    "_id": {
        "$oid": "#######"
    },
    "slackUsername": "johnny",
    "__v": 0,
    "jiraToken": "FOO",
    "jiraTokenSecret": "BAR",
    "jiraUsername":  "[~john]"
}
```

AFTER

```
{
    "_id": {
        "$oid": "#######"
    },
    "slackUsername": "johnny",
    "__v": 0,
    "jiraToken": "FOO",
    "jiraTokenSecret": "BAR",
    "jiraUsername": "[~accountid:######]",
    "jiraShortName": "[~john]"
}
```

So then we use the userame when jira talks to us, and use the short name to talk to slack and jira